### PR TITLE
allow skipping saving the layers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ inputs:
   skip-save:
     description: Skip saving layers in the post step
     required: false
+    default: 'false'
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,17 @@ inputs:
     required: true
     default: docker-layer-caching-${{ github.workflow }}-{hash}
   restore-keys:
-    description: An ordered list of keys to use for restoring the cache if no cache hit occurred for key 
+    description: An ordered list of keys to use for restoring the cache if no cache hit occurred for key
     required: false
     default: docker-layer-caching-${{ github.workflow }}-
   concurrency:
     description: The number of concurrency when restoring and saving layers
     required: true
     default: '4'
+  skip-save:
+    description: Skip saving layers in the post step
+    required: false
+    default: false
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,6 @@ inputs:
   skip-save:
     description: Skip saving layers in the post step
     required: false
-    default: false
 
 runs:
   using: node12

--- a/post.ts
+++ b/post.ts
@@ -5,6 +5,11 @@ import { LayerCache } from './src/LayerCache'
 import { ImageDetector } from './src/ImageDetector'
 import { assertType } from 'typescript-is'
 const main = async () => {
+  if (core.getInput('skip-save')) {
+    core.info('Skipping save.')
+    return
+  }
+
   const primaryKey = core.getInput('key', { required: true })
   const restoredKey = JSON.parse(core.getState(`restored-key`)) as string
 

--- a/post.ts
+++ b/post.ts
@@ -6,7 +6,7 @@ import { ImageDetector } from './src/ImageDetector'
 import { assertType } from 'typescript-is'
 
 const main = async () => {
-  if (core.getInput('skip-save') != null) {
+  if (JSON.parse(core.getInput('skip-save', { required: true }))) {
     core.info('Skipping save.')
     return
   }

--- a/post.ts
+++ b/post.ts
@@ -4,8 +4,9 @@ import exec from 'actions-exec-listener'
 import { LayerCache } from './src/LayerCache'
 import { ImageDetector } from './src/ImageDetector'
 import { assertType } from 'typescript-is'
+
 const main = async () => {
-  if (core.getInput('skip-save')) {
+  if (core.getInput('skip-save') != null) {
     core.info('Skipping save.')
     return
   }


### PR DESCRIPTION
This allows you skipping the whole post step of trying to save the layers. The use case here being I'm caching the build from a previous step and running tests. I don't need to save the layers again.

Use case repo: https://github.com/btkostner/neon/runs/974278660?check_suite_focus=true