### PR TITLE
Save only when new images were created

### DIFF
--- a/post.ts
+++ b/post.ts
@@ -21,17 +21,15 @@ const main = async () => {
   assertType<string[]>(restoredImages)
 
   const imageDetector = new ImageDetector()
-  if (await imageDetector.checkIfImageHasAdded(restoredImages)) {
-    core.info(`Key ${restoredKey} already exists, not saving cache.`)
-    return
-  }
 
-  const imagesToSave = await imageDetector.getImagesShouldSave(alreadyExistingImages)
-  if (imagesToSave.length < 1) {
+  const existingAndRestoredImages = alreadyExistingImages.concat(restoredImages)
+  const newImages = await imageDetector.getImagesShouldSave(existingAndRestoredImages)
+  if (newImages.length < 1) {
     core.info(`There is no image to save.`)
     return
   }
 
+  const imagesToSave = await imageDetector.getImagesShouldSave(alreadyExistingImages)
   const layerCache = new LayerCache(imagesToSave)
   layerCache.concurrency = parseInt(core.getInput(`concurrency`, { required: true }), 10)
 

--- a/src/ImageDetector.ts
+++ b/src/ImageDetector.ts
@@ -17,9 +17,4 @@ export class ImageDetector {
     alreadRegisteredImages.forEach(image => resultSet.delete(image))
     return Array.from(resultSet)
   }
-
-  async checkIfImageHasAdded(restoredImages: string[]): Promise<boolean> {
-    const existing = await this.getExistingImages()
-    return JSON.stringify(restoredImages) === JSON.stringify(existing)
-  }
 }


### PR DESCRIPTION
As described in #81, this action often saves a new cache even though no new images were created. This happens when there were images preloaded and then the action restored a cache successfully.

In that case, checkIfImageHasAdded returns true because existingImages includes the preloaded images as well as the restored ones. That bypasses this check:
https://github.com/satackey/action-docker-layer-caching/blob/b01c39f01d22471c181e47f8506ec3ae720b8454/post.ts#L24

Then getImagesShouldSave returns the list of restored images, so the next check passes because imagesToSave isn't empty.
https://github.com/satackey/action-docker-layer-caching/blob/b01c39f01d22471c181e47f8506ec3ae720b8454/post.ts#L30

This change ignores restored images when checking if new images were created. When new image(s) are detected they're saved with the restored images in the new cache. This is so that unchanged images aren't lost when other images are rebuilt.

Fixes #81