### PR TITLE
Use path module instead of string manipulation

### DIFF
--- a/src/Tar.ts
+++ b/src/Tar.ts
@@ -1,5 +1,6 @@
 import { assertType } from 'typescript-is' 
 import { promises as fs } from 'fs'
+import * as path from 'path'
 
 export interface Manifest {
   Config: string
@@ -13,8 +14,8 @@ export function assertManifests(x: unknown): asserts x is Manifests {
   assertType<Manifests>(x)
 }
 
-export async function loadRawManifests(path: string) {
-  return (await fs.readFile(`${path}/manifest.json`)).toString()
+export async function loadRawManifests(rootPath: string) {
+  return (await fs.readFile(path.join(rootPath, `manifest.json`))).toString()
 }
 
 export async function loadManifests(path: string) {


### PR DESCRIPTION
This updates all path-handling code to use the node `path` module for cross-platform support.

Fixes #87 (a bug on Windows where all layer content was kept in the root cache and layer caches were empty folders)