### PR TITLE
Detect updated "cache exists" error message

### DIFF
--- a/src/LayerCache.ts
+++ b/src/LayerCache.ts
@@ -18,7 +18,7 @@ class LayerCache {
   enabledParallel = true
   concurrency: number = 4
 
-  static ERROR_CACHE_ALREAD_EXISTS_STR = `Cache already exists`
+  static ERROR_CACHE_ALREAD_EXISTS_STR = `Unable to reserve cache with key`
   static ERROR_LAYER_CACHE_NOT_FOUND_STR = `Layer cache not found`
 
   constructor(ids: string[]) {


### PR DESCRIPTION
Something has changed on the caching service, which now returns a new message the cache key already exists. This changes the string used to detect that error so it can be ignored as expected. Fixes #85.

BTW: No worries if you don't want to merge a PR for a one line fix. Feel free to commit the change directly to master if you want.