### PR TITLE
Support saving images which are identified by SHA rather than tag

### DIFF
--- a/src/ImageDetector.ts
+++ b/src/ImageDetector.ts
@@ -5,11 +5,27 @@ export class ImageDetector {
   async getExistingImages(): Promise<string[]> {
     const existingSet = new Set<string>([])
     const ids = (await exec.exec(`docker image ls -q`, [], { silent: true, listeners: { stderr: console.warn }})).stdoutStr.split(`\n`).filter(id => id !== ``)
-    const repotags = (await exec.exec(`docker`, `image ls --format {{.Repository}}:{{.Tag}} --filter dangling=false`.split(' '), { silent: true, listeners: { stderr: console.warn }})).stdoutStr.split(`\n`).filter(id => id !== ``);
+    const repotags = await this.getExistingImageIdentifiers()
     core.debug(JSON.stringify({ log: "getExistingImages", ids, repotags }));
     ([...ids, ...repotags]).forEach(image => existingSet.add(image))
     core.debug(JSON.stringify({ existingSet }))
     return Array.from(existingSet)
+  }
+
+  async getExistingImageIdentifiers(): Promise<string[]> {
+    return (
+        await exec.exec(
+          `docker`, `image ls --format {{.Repository}}:{{.Tag}}:{{.ID}} --filter dangling=false`.split(' '),
+          { silent: true, listeners: { stderr: console.warn }}
+        )
+      )
+        .stdoutStr
+        .split(`\n`)
+        .filter(img => img !== ``)
+        .map(img => {
+          const [repository, tag, id] = img.split(':')
+          return (tag == '<none>' ? id : `${repository}:${tag}`)
+        })
   }
 
   async getImagesShouldSave(alreadRegisteredImages: string[]): Promise<string[]> {


### PR DESCRIPTION
Hopefully resolves https://github.com/satackey/action-docker-layer-caching/issues/17 and https://github.com/satackey/action-docker-layer-caching/issues/49.

Images can be pulled by SHA, but these don't get tagged, e.g.:

```
ruby:2.7.2-slim-buster@sha256:b9eebc5a6956f1def4698fac0930e7a1398a50c4198313fe87af0402cab8d149
```

We can't then use the repo plus non-existent tag to identify it in the call to `docker save`. Instead, we can use the image ID, e.g.:

```
docker save redis:3.0 | tar xf - -C output1
docker save c44fa74ead88 | tar xf - -C output2
```

I'm fetching these details via:

```
$ docker image ls --format {{.Repository}}:{{.Tag}}:{{.ID}} --filter dangling=false
ruby:2.4:f172588bbb0b
ruby:<none>:ad10dfbc638b
...
```

This project badly needs some tests. In order to test this locally, I had to do so rather hackily.

I haven't tested out restoring yet. Putting this up here to share my progress.